### PR TITLE
Fixed C++ extensions compiler error

### DIFF
--- a/Standalone/KPConvX/cpp_wrappers/cpp_neighbors/wrapper.cpp
+++ b/Standalone/KPConvX/cpp_wrappers/cpp_neighbors/wrapper.cpp
@@ -128,7 +128,7 @@ static PyObject* batch_radius_neighbors(PyObject* self, PyObject* args, PyObject
 	}
 
 	// Check that the input array respect the dims
-	if ((int)PyArray_NDIM(queries_array) != 2 || (int)PyArray_DIM(queries_array, 1) != 3)
+	if ((int)PyArray_NDIM((PyArrayObject*)queries_array) != 2 || (int)PyArray_DIM((PyArrayObject*)queries_array, 1) != 3)
 	{
 		Py_XDECREF(queries_array);
 		Py_XDECREF(supports_array);
@@ -137,7 +137,7 @@ static PyObject* batch_radius_neighbors(PyObject* self, PyObject* args, PyObject
 		PyErr_SetString(PyExc_RuntimeError, "Wrong dimensions : query.shape is not (N, 3)");
 		return NULL;
 	}
-	if ((int)PyArray_NDIM(supports_array) != 2 || (int)PyArray_DIM(supports_array, 1) != 3)
+	if ((int)PyArray_NDIM((PyArrayObject*)supports_array) != 2 || (int)PyArray_DIM((PyArrayObject*)supports_array, 1) != 3)
 	{
 		Py_XDECREF(queries_array);
 		Py_XDECREF(supports_array);
@@ -146,7 +146,7 @@ static PyObject* batch_radius_neighbors(PyObject* self, PyObject* args, PyObject
 		PyErr_SetString(PyExc_RuntimeError, "Wrong dimensions : support.shape is not (N, 3)");
 		return NULL;
 	}
-	if ((int)PyArray_NDIM(q_batches_array) > 1)
+	if ((int)PyArray_NDIM((PyArrayObject*)q_batches_array) > 1)
 	{
 		Py_XDECREF(queries_array);
 		Py_XDECREF(supports_array);
@@ -155,7 +155,7 @@ static PyObject* batch_radius_neighbors(PyObject* self, PyObject* args, PyObject
 		PyErr_SetString(PyExc_RuntimeError, "Wrong dimensions : queries_batches.shape is not (B,) ");
 		return NULL;
 	}
-	if ((int)PyArray_NDIM(s_batches_array) > 1)
+	if ((int)PyArray_NDIM((PyArrayObject*)s_batches_array) > 1)
 	{
 		Py_XDECREF(queries_array);
 		Py_XDECREF(supports_array);
@@ -164,7 +164,7 @@ static PyObject* batch_radius_neighbors(PyObject* self, PyObject* args, PyObject
 		PyErr_SetString(PyExc_RuntimeError, "Wrong dimensions : supports_batches.shape is not (B,) ");
 		return NULL;
 	}
-	if ((int)PyArray_DIM(q_batches_array, 0) != (int)PyArray_DIM(s_batches_array, 0))
+	if ((int)PyArray_DIM((PyArrayObject*)q_batches_array, 0) != (int)PyArray_DIM((PyArrayObject*)s_batches_array, 0))
 	{
 		Py_XDECREF(queries_array);
 		Py_XDECREF(supports_array);
@@ -175,11 +175,11 @@ static PyObject* batch_radius_neighbors(PyObject* self, PyObject* args, PyObject
 	}
 
 	// Number of points
-	int Nq = (int)PyArray_DIM(queries_array, 0);
-	int Ns= (int)PyArray_DIM(supports_array, 0);
+	int Nq = (int)PyArray_DIM((PyArrayObject*)queries_array, 0);
+	int Ns= (int)PyArray_DIM((PyArrayObject*)supports_array, 0);
 
 	// Number of batches
-	int Nb = (int)PyArray_DIM(q_batches_array, 0);
+	int Nb = (int)PyArray_DIM((PyArrayObject*)q_batches_array, 0);
 
 	// Call the C++ function
 	// *********************
@@ -189,10 +189,10 @@ static PyObject* batch_radius_neighbors(PyObject* self, PyObject* args, PyObject
 	vector<PointXYZ> supports;
 	vector<int> q_batches;
 	vector<int> s_batches;
-	queries = vector<PointXYZ>((PointXYZ*)PyArray_DATA(queries_array), (PointXYZ*)PyArray_DATA(queries_array) + Nq);
-	supports = vector<PointXYZ>((PointXYZ*)PyArray_DATA(supports_array), (PointXYZ*)PyArray_DATA(supports_array) + Ns);
-	q_batches = vector<int>((int*)PyArray_DATA(q_batches_array), (int*)PyArray_DATA(q_batches_array) + Nb);
-	s_batches = vector<int>((int*)PyArray_DATA(s_batches_array), (int*)PyArray_DATA(s_batches_array) + Nb);
+	queries = vector<PointXYZ>((PointXYZ*)PyArray_DATA((PyArrayObject*)queries_array), (PointXYZ*)PyArray_DATA((PyArrayObject*)queries_array) + Nq);
+	supports = vector<PointXYZ>((PointXYZ*)PyArray_DATA((PyArrayObject*)supports_array), (PointXYZ*)PyArray_DATA((PyArrayObject*)supports_array) + Ns);
+	q_batches = vector<int>((int*)PyArray_DATA((PyArrayObject*)q_batches_array), (int*)PyArray_DATA((PyArrayObject*)q_batches_array) + Nb);
+	s_batches = vector<int>((int*)PyArray_DATA((PyArrayObject*)s_batches_array), (int*)PyArray_DATA((PyArrayObject*)s_batches_array) + Nb);
 
 	// Create result containers
 	vector<int> neighbors_indices;
@@ -225,7 +225,7 @@ static PyObject* batch_radius_neighbors(PyObject* self, PyObject* args, PyObject
 
 	// Fill output array with values
 	size_t size_in_bytes = Nq * max_neighbors * sizeof(int);
-	memcpy(PyArray_DATA(res_obj), neighbors_indices.data(), size_in_bytes);
+	memcpy(PyArray_DATA((PyArrayObject*)res_obj), neighbors_indices.data(), size_in_bytes);
 
 	// Merge results
 	ret = Py_BuildValue("N", res_obj);
@@ -314,7 +314,7 @@ static PyObject* batch_knn_neighbors(PyObject* self, PyObject* args, PyObject* k
 	}
 
 	// Check that the input array respect the dims
-	if ((int)PyArray_NDIM(queries_array) != 2 || (int)PyArray_DIM(queries_array, 1) != 3)
+	if ((int)PyArray_NDIM((PyArrayObject*)queries_array) != 2 || (int)PyArray_DIM((PyArrayObject*)queries_array, 1) != 3)
 	{
 		Py_XDECREF(queries_array);
 		Py_XDECREF(supports_array);
@@ -323,7 +323,7 @@ static PyObject* batch_knn_neighbors(PyObject* self, PyObject* args, PyObject* k
 		PyErr_SetString(PyExc_RuntimeError, "Wrong dimensions : query.shape is not (N, 3)");
 		return NULL;
 	}
-	if ((int)PyArray_NDIM(supports_array) != 2 || (int)PyArray_DIM(supports_array, 1) != 3)
+	if ((int)PyArray_NDIM((PyArrayObject*)supports_array) != 2 || (int)PyArray_DIM((PyArrayObject*)supports_array, 1) != 3)
 	{
 		Py_XDECREF(queries_array);
 		Py_XDECREF(supports_array);
@@ -332,7 +332,7 @@ static PyObject* batch_knn_neighbors(PyObject* self, PyObject* args, PyObject* k
 		PyErr_SetString(PyExc_RuntimeError, "Wrong dimensions : support.shape is not (N, 3)");
 		return NULL;
 	}
-	if ((int)PyArray_NDIM(q_batches_array) > 1)
+	if ((int)PyArray_NDIM((PyArrayObject*)q_batches_array) > 1)
 	{
 		Py_XDECREF(queries_array);
 		Py_XDECREF(supports_array);
@@ -341,7 +341,7 @@ static PyObject* batch_knn_neighbors(PyObject* self, PyObject* args, PyObject* k
 		PyErr_SetString(PyExc_RuntimeError, "Wrong dimensions : queries_batches.shape is not (B,) ");
 		return NULL;
 	}
-	if ((int)PyArray_NDIM(s_batches_array) > 1)
+	if ((int)PyArray_NDIM((PyArrayObject*)s_batches_array) > 1)
 	{
 		Py_XDECREF(queries_array);
 		Py_XDECREF(supports_array);
@@ -350,7 +350,7 @@ static PyObject* batch_knn_neighbors(PyObject* self, PyObject* args, PyObject* k
 		PyErr_SetString(PyExc_RuntimeError, "Wrong dimensions : supports_batches.shape is not (B,) ");
 		return NULL;
 	}
-	if ((int)PyArray_DIM(q_batches_array, 0) != (int)PyArray_DIM(s_batches_array, 0))
+	if ((int)PyArray_DIM((PyArrayObject*)q_batches_array, 0) != (int)PyArray_DIM((PyArrayObject*)s_batches_array, 0))
 	{
 		Py_XDECREF(queries_array);
 		Py_XDECREF(supports_array);
@@ -361,11 +361,11 @@ static PyObject* batch_knn_neighbors(PyObject* self, PyObject* args, PyObject* k
 	}
 
 	// Number of points
-	int Nq = (int)PyArray_DIM(queries_array, 0);
-	int Ns = (int)PyArray_DIM(supports_array, 0);
+	int Nq = (int)PyArray_DIM((PyArrayObject*)queries_array, 0);
+	int Ns = (int)PyArray_DIM((PyArrayObject*)supports_array, 0);
 
 	// Number of batches
-	int Nb = (int)PyArray_DIM(q_batches_array, 0);
+	int Nb = (int)PyArray_DIM((PyArrayObject*)q_batches_array, 0);
 
 	// Call the C++ function
 	// *********************
@@ -375,10 +375,10 @@ static PyObject* batch_knn_neighbors(PyObject* self, PyObject* args, PyObject* k
 	vector<PointXYZ> supports;
 	vector<int> q_batches;
 	vector<int> s_batches;
-	queries = vector<PointXYZ>((PointXYZ*)PyArray_DATA(queries_array), (PointXYZ*)PyArray_DATA(queries_array) + Nq);
-	supports = vector<PointXYZ>((PointXYZ*)PyArray_DATA(supports_array), (PointXYZ*)PyArray_DATA(supports_array) + Ns);
-	q_batches = vector<int>((int*)PyArray_DATA(q_batches_array), (int*)PyArray_DATA(q_batches_array) + Nb);
-	s_batches = vector<int>((int*)PyArray_DATA(s_batches_array), (int*)PyArray_DATA(s_batches_array) + Nb);
+	queries = vector<PointXYZ>((PointXYZ*)PyArray_DATA((PyArrayObject*)queries_array), (PointXYZ*)PyArray_DATA((PyArrayObject*)queries_array) + Nq);
+	supports = vector<PointXYZ>((PointXYZ*)PyArray_DATA((PyArrayObject*)supports_array), (PointXYZ*)PyArray_DATA((PyArrayObject*)supports_array) + Ns);
+	q_batches = vector<int>((int*)PyArray_DATA((PyArrayObject*)q_batches_array), (int*)PyArray_DATA((PyArrayObject*)q_batches_array) + Nb);
+	s_batches = vector<int>((int*)PyArray_DATA((PyArrayObject*)s_batches_array), (int*)PyArray_DATA((PyArrayObject*)s_batches_array) + Nb);
 
 	// Create result containers
 	vector<int> neighbors_indices;
@@ -410,9 +410,9 @@ static PyObject* batch_knn_neighbors(PyObject* self, PyObject* args, PyObject* k
 
 	// Fill output array with values
 	size_t size_in_bytes = Nq * n_neighbors * sizeof(int);
-	memcpy(PyArray_DATA(res_obj_n), neighbors_indices.data(), size_in_bytes);
+	memcpy(PyArray_DATA((PyArrayObject*)res_obj_n), neighbors_indices.data(), size_in_bytes);
 	size_t size_in_bytes2 = Nq * n_neighbors * sizeof(float);
-	memcpy(PyArray_DATA(res_obj_d2), neighbors_sqdist.data(), size_in_bytes2);
+	memcpy(PyArray_DATA((PyArrayObject*)res_obj_d2), neighbors_sqdist.data(), size_in_bytes2);
 
 	// Merge results
 	ret = Py_BuildValue("NN", res_obj_n, res_obj_d2);

--- a/Standalone/KPConvX/cpp_wrappers/cpp_subsampling/wrapper.cpp
+++ b/Standalone/KPConvX/cpp_wrappers/cpp_subsampling/wrapper.cpp
@@ -160,7 +160,7 @@ static PyObject* batch_subsampling(PyObject* self, PyObject* args, PyObject* key
 	}
 
 	// Check that the input array respect the dims
-	if ((int)PyArray_NDIM(points_array) != 2 || (int)PyArray_DIM(points_array, 1) != 3)
+	if ((int)PyArray_NDIM((PyArrayObject*)points_array) != 2 || (int)PyArray_DIM((PyArrayObject*)points_array, 1) != 3)
 	{
 		Py_XDECREF(points_array);
 		Py_XDECREF(batches_array);
@@ -169,7 +169,7 @@ static PyObject* batch_subsampling(PyObject* self, PyObject* args, PyObject* key
 		PyErr_SetString(PyExc_RuntimeError, "Wrong dimensions : points.shape is not (N, 3)");
 		return NULL;
 	}
-	if ((int)PyArray_NDIM(batches_array) > 1)
+	if ((int)PyArray_NDIM((PyArrayObject*)batches_array) > 1)
 	{
 		Py_XDECREF(points_array);
 		Py_XDECREF(batches_array);
@@ -178,7 +178,7 @@ static PyObject* batch_subsampling(PyObject* self, PyObject* args, PyObject* key
 		PyErr_SetString(PyExc_RuntimeError, "Wrong dimensions : batches.shape is not (B,) ");
 		return NULL;
 	}
-	if (use_feature && ((int)PyArray_NDIM(features_array) != 2))
+	if (use_feature && ((int)PyArray_NDIM((PyArrayObject*)features_array) != 2))
 	{
 		Py_XDECREF(points_array);
 		Py_XDECREF(batches_array);
@@ -188,7 +188,7 @@ static PyObject* batch_subsampling(PyObject* self, PyObject* args, PyObject* key
 		return NULL;
 	}
 
-	if (use_classes && (int)PyArray_NDIM(classes_array) > 2)
+	if (use_classes && (int)PyArray_NDIM((PyArrayObject*)classes_array) > 2)
 	{
 		Py_XDECREF(points_array);
 		Py_XDECREF(batches_array);
@@ -199,23 +199,23 @@ static PyObject* batch_subsampling(PyObject* self, PyObject* args, PyObject* key
 	}
 
 	// Number of points
-	int N = (int)PyArray_DIM(points_array, 0);
+	int N = (int)PyArray_DIM((PyArrayObject*)points_array, 0);
 
 	// Number of batches
-	int Nb = (int)PyArray_DIM(batches_array, 0);
+	int Nb = (int)PyArray_DIM((PyArrayObject*)batches_array, 0);
 
 	// Dimension of the features
 	int fdim = 0;
 	if (use_feature)
-		fdim = (int)PyArray_DIM(features_array, 1);
+		fdim = (int)PyArray_DIM((PyArrayObject*)features_array, 1);
 
 	//Dimension of labels
 	int ldim = 1;
-	if (use_classes && (int)PyArray_NDIM(classes_array) == 2)
-		ldim = (int)PyArray_DIM(classes_array, 1);
+	if (use_classes && (int)PyArray_NDIM((PyArrayObject*)classes_array) == 2)
+		ldim = (int)PyArray_DIM((PyArrayObject*)classes_array, 1);
 
 	// Check that the input array respect the number of points
-	if (use_feature && (int)PyArray_DIM(features_array, 0) != N)
+	if (use_feature && (int)PyArray_DIM((PyArrayObject*)features_array, 0) != N)
 	{
 		Py_XDECREF(points_array);
 		Py_XDECREF(batches_array);
@@ -224,7 +224,7 @@ static PyObject* batch_subsampling(PyObject* self, PyObject* args, PyObject* key
 		PyErr_SetString(PyExc_RuntimeError, "Wrong dimensions : features.shape is not (N, d)");
 		return NULL;
 	}
-	if (use_classes && (int)PyArray_DIM(classes_array, 0) != N)
+	if (use_classes && (int)PyArray_DIM((PyArrayObject*)classes_array, 0) != N)
 	{
 		Py_XDECREF(points_array);
 		Py_XDECREF(batches_array);
@@ -248,12 +248,12 @@ static PyObject* batch_subsampling(PyObject* self, PyObject* args, PyObject* key
 	vector<int> original_batches;
 	vector<float> original_features;
 	vector<int> original_classes;
-	original_points = vector<PointXYZ>((PointXYZ*)PyArray_DATA(points_array), (PointXYZ*)PyArray_DATA(points_array) + N);
-	original_batches = vector<int>((int*)PyArray_DATA(batches_array), (int*)PyArray_DATA(batches_array) + Nb);
+	original_points = vector<PointXYZ>((PointXYZ*)PyArray_DATA((PyArrayObject*)points_array), (PointXYZ*)PyArray_DATA((PyArrayObject*)points_array) + N);
+	original_batches = vector<int>((int*)PyArray_DATA((PyArrayObject*)batches_array), (int*)PyArray_DATA((PyArrayObject*)batches_array) + Nb);
 	if (use_feature)
-		original_features = vector<float>((float*)PyArray_DATA(features_array), (float*)PyArray_DATA(features_array) + N * fdim);
+		original_features = vector<float>((float*)PyArray_DATA((PyArrayObject*)features_array), (float*)PyArray_DATA((PyArrayObject*)features_array) + N * fdim);
 	if (use_classes)
-		original_classes = vector<int>((int*)PyArray_DATA(classes_array), (int*)PyArray_DATA(classes_array) + N * ldim);
+		original_classes = vector<int>((int*)PyArray_DATA((PyArrayObject*)classes_array), (int*)PyArray_DATA((PyArrayObject*)classes_array) + N * ldim);
 
 	// Subsample
 	vector<PointXYZ> subsampled_points;
@@ -303,20 +303,20 @@ static PyObject* batch_subsampling(PyObject* self, PyObject* args, PyObject* key
 
 	// Fill output array with values
 	size_t size_in_bytes = subsampled_points.size() * 3 * sizeof(float);
-	memcpy(PyArray_DATA(res_points_obj), subsampled_points.data(), size_in_bytes);
+	memcpy(PyArray_DATA((PyArrayObject*)res_points_obj), subsampled_points.data(), size_in_bytes);
 	size_in_bytes = Nb * sizeof(int);
-	memcpy(PyArray_DATA(res_batches_obj), subsampled_batches.data(), size_in_bytes);
+	memcpy(PyArray_DATA((PyArrayObject*)res_batches_obj), subsampled_batches.data(), size_in_bytes);
 	if (use_feature)
 	{
 		size_in_bytes = subsampled_points.size() * fdim * sizeof(float);
 		res_features_obj = PyArray_SimpleNew(2, feature_dims, NPY_FLOAT);
-		memcpy(PyArray_DATA(res_features_obj), subsampled_features.data(), size_in_bytes);
+		memcpy(PyArray_DATA((PyArrayObject*)res_features_obj), subsampled_features.data(), size_in_bytes);
 	}
 	if (use_classes)
 	{
 		size_in_bytes = subsampled_points.size() * ldim * sizeof(int);
 		res_classes_obj = PyArray_SimpleNew(2, classes_dims, NPY_INT);
-		memcpy(PyArray_DATA(res_classes_obj), subsampled_classes.data(), size_in_bytes);
+		memcpy(PyArray_DATA((PyArrayObject*)res_classes_obj), subsampled_classes.data(), size_in_bytes);
 	}
 
 
@@ -421,7 +421,7 @@ static PyObject* cloud_subsampling(PyObject* self, PyObject* args, PyObject* key
 	}
 
 	// Check that the input array respect the dims
-	if ((int)PyArray_NDIM(points_array) != 2 || (int)PyArray_DIM(points_array, 1) != 3)
+	if ((int)PyArray_NDIM((PyArrayObject*)points_array) != 2 || (int)PyArray_DIM((PyArrayObject*)points_array, 1) != 3)
 	{
 		Py_XDECREF(points_array);
 		Py_XDECREF(classes_array);
@@ -429,7 +429,7 @@ static PyObject* cloud_subsampling(PyObject* self, PyObject* args, PyObject* key
 		PyErr_SetString(PyExc_RuntimeError, "Wrong dimensions : points.shape is not (N, 3)");
 		return NULL;
 	}
-	if (use_feature && ((int)PyArray_NDIM(features_array) != 2))
+	if (use_feature && ((int)PyArray_NDIM((PyArrayObject*)features_array) != 2))
 	{
 		Py_XDECREF(points_array);
 		Py_XDECREF(classes_array);
@@ -438,7 +438,7 @@ static PyObject* cloud_subsampling(PyObject* self, PyObject* args, PyObject* key
 		return NULL;
 	}
 
-	if (use_classes && (int)PyArray_NDIM(classes_array) > 2)
+	if (use_classes && (int)PyArray_NDIM((PyArrayObject*)classes_array) > 2)
 	{
 		Py_XDECREF(points_array);
 		Py_XDECREF(classes_array);
@@ -448,20 +448,20 @@ static PyObject* cloud_subsampling(PyObject* self, PyObject* args, PyObject* key
 	}
 
 	// Number of points
-	int N = (int)PyArray_DIM(points_array, 0);
+	int N = (int)PyArray_DIM((PyArrayObject*)points_array, 0);
 
 	// Dimension of the features
 	int fdim = 0;
 	if (use_feature)
-		fdim = (int)PyArray_DIM(features_array, 1);
+		fdim = (int)PyArray_DIM((PyArrayObject*)features_array, 1);
 
 	//Dimension of labels
 	int ldim = 1;
-	if (use_classes && (int)PyArray_NDIM(classes_array) == 2)
-		ldim = (int)PyArray_DIM(classes_array, 1);
+	if (use_classes && (int)PyArray_NDIM((PyArrayObject*)classes_array) == 2)
+		ldim = (int)PyArray_DIM((PyArrayObject*)classes_array, 1);
 
 	// Check that the input array respect the number of points
-	if (use_feature && (int)PyArray_DIM(features_array, 0) != N)
+	if (use_feature && (int)PyArray_DIM((PyArrayObject*)features_array, 0) != N)
 	{
 		Py_XDECREF(points_array);
 		Py_XDECREF(classes_array);
@@ -469,7 +469,7 @@ static PyObject* cloud_subsampling(PyObject* self, PyObject* args, PyObject* key
 		PyErr_SetString(PyExc_RuntimeError, "Wrong dimensions : features.shape is not (N, d)");
 		return NULL;
 	}
-	if (use_classes && (int)PyArray_DIM(classes_array, 0) != N)
+	if (use_classes && (int)PyArray_DIM((PyArrayObject*)classes_array, 0) != N)
 	{
 		Py_XDECREF(points_array);
 		Py_XDECREF(classes_array);
@@ -491,11 +491,11 @@ static PyObject* cloud_subsampling(PyObject* self, PyObject* args, PyObject* key
 	vector<PointXYZ> original_points;
 	vector<float> original_features;
 	vector<int> original_classes;
-	original_points = vector<PointXYZ>((PointXYZ*)PyArray_DATA(points_array), (PointXYZ*)PyArray_DATA(points_array) + N);
+	original_points = vector<PointXYZ>((PointXYZ*)PyArray_DATA((PyArrayObject*)points_array), (PointXYZ*)PyArray_DATA((PyArrayObject*)points_array) + N);
 	if (use_feature)
-		original_features = vector<float>((float*)PyArray_DATA(features_array), (float*)PyArray_DATA(features_array) + N * fdim);
+		original_features = vector<float>((float*)PyArray_DATA((PyArrayObject*)features_array), (float*)PyArray_DATA((PyArrayObject*)features_array) + N * fdim);
 	if (use_classes)
-		original_classes = vector<int>((int*)PyArray_DATA(classes_array), (int*)PyArray_DATA(classes_array) + N * ldim);
+		original_classes = vector<int>((int*)PyArray_DATA((PyArrayObject*)classes_array), (int*)PyArray_DATA((PyArrayObject*)classes_array) + N * ldim);
 
 	// Subsample
 	vector<PointXYZ> subsampled_points;
@@ -539,18 +539,18 @@ static PyObject* cloud_subsampling(PyObject* self, PyObject* args, PyObject* key
 
 	// Fill output array with values
 	size_t size_in_bytes = subsampled_points.size() * 3 * sizeof(float);
-	memcpy(PyArray_DATA(res_points_obj), subsampled_points.data(), size_in_bytes);
+	memcpy(PyArray_DATA((PyArrayObject*)res_points_obj), subsampled_points.data(), size_in_bytes);
 	if (use_feature)
 	{
 		size_in_bytes = subsampled_points.size() * fdim * sizeof(float);
 		res_features_obj = PyArray_SimpleNew(2, feature_dims, NPY_FLOAT);
-		memcpy(PyArray_DATA(res_features_obj), subsampled_features.data(), size_in_bytes);
+		memcpy(PyArray_DATA((PyArrayObject*)res_features_obj), subsampled_features.data(), size_in_bytes);
 	}
 	if (use_classes)
 	{
 		size_in_bytes = subsampled_points.size() * ldim * sizeof(int);
 		res_classes_obj = PyArray_SimpleNew(2, classes_dims, NPY_INT);
-		memcpy(PyArray_DATA(res_classes_obj), subsampled_classes.data(), size_in_bytes);
+		memcpy(PyArray_DATA((PyArrayObject*)res_classes_obj), subsampled_classes.data(), size_in_bytes);
 	}
 
 
@@ -613,7 +613,7 @@ static PyObject* furthest_point_sampling(PyObject* self, PyObject* args, PyObjec
 	}
 
 	// Check that the input array respect the dims
-	if ((int)PyArray_NDIM(points_array) != 2 || (int)PyArray_DIM(points_array, 1) != 3)
+	if ((int)PyArray_NDIM((PyArrayObject*)points_array) != 2 || (int)PyArray_DIM((PyArrayObject*)points_array, 1) != 3)
 	{
 		Py_XDECREF(points_array);
 		PyErr_SetString(PyExc_RuntimeError, "Wrong dimensions : points.shape is not (N, 3)");
@@ -621,7 +621,7 @@ static PyObject* furthest_point_sampling(PyObject* self, PyObject* args, PyObjec
 	}
 
 	// Number of points
-	int N = (int)PyArray_DIM(points_array, 0);
+	int N = (int)PyArray_DIM((PyArrayObject*)points_array, 0);
 
 
 	// Call the C++ function
@@ -629,7 +629,7 @@ static PyObject* furthest_point_sampling(PyObject* self, PyObject* args, PyObjec
 
 	// Convert PyArray to Cloud C++ class
 	vector<PointXYZ> original_points;
-	original_points = vector<PointXYZ>((PointXYZ*)PyArray_DATA(points_array), (PointXYZ*)PyArray_DATA(points_array) + N);
+	original_points = vector<PointXYZ>((PointXYZ*)PyArray_DATA((PyArrayObject*)points_array), (PointXYZ*)PyArray_DATA((PyArrayObject*)points_array) + N);
 
 	// Subsample
 	vector<int> subsampled_inds;
@@ -659,7 +659,7 @@ static PyObject* furthest_point_sampling(PyObject* self, PyObject* args, PyObjec
 
 	// Fill output array with values
 	size_t size_in_bytes = subsampled_inds.size() * sizeof(int);
-	memcpy(PyArray_DATA(res_points_obj), subsampled_inds.data(), size_in_bytes);
+	memcpy(PyArray_DATA((PyArrayObject*)res_points_obj), subsampled_inds.data(), size_in_bytes);
 
 	// Merge results
 	ret = Py_BuildValue("N", res_points_obj);
@@ -731,14 +731,14 @@ static PyObject* batch_grid_partitionning(PyObject* self, PyObject* args, PyObje
 	}
 
 	// Check that the input array respect the dims
-	if ((int)PyArray_NDIM(points_array) != 2 || (int)PyArray_DIM(points_array, 1) != 3)
+	if ((int)PyArray_NDIM((PyArrayObject*)points_array) != 2 || (int)PyArray_DIM((PyArrayObject*)points_array, 1) != 3)
 	{
 		Py_XDECREF(points_array);
 		Py_XDECREF(batches_array);
 		PyErr_SetString(PyExc_RuntimeError, "Wrong dimensions : points.shape is not (N, 3)");
 		return NULL;
 	}
-	if ((int)PyArray_NDIM(batches_array) > 1)
+	if ((int)PyArray_NDIM((PyArrayObject*)batches_array) > 1)
 	{
 		Py_XDECREF(points_array);
 		Py_XDECREF(batches_array);
@@ -747,10 +747,10 @@ static PyObject* batch_grid_partitionning(PyObject* self, PyObject* args, PyObje
 	}
 
 	// Number of points
-	int N = (int)PyArray_DIM(points_array, 0);
+	int N = (int)PyArray_DIM((PyArrayObject*)points_array, 0);
 
 	// Number of batches
-	int Nb = (int)PyArray_DIM(batches_array, 0);
+	int Nb = (int)PyArray_DIM((PyArrayObject*)batches_array, 0);
 
 
 	// Call the C++ function
@@ -761,8 +761,8 @@ static PyObject* batch_grid_partitionning(PyObject* self, PyObject* args, PyObje
 	vector<int> original_batches;
 	vector<float> original_features;
 	vector<int> original_classes;
-	original_points = vector<PointXYZ>((PointXYZ*)PyArray_DATA(points_array), (PointXYZ*)PyArray_DATA(points_array) + N);
-	original_batches = vector<int>((int*)PyArray_DATA(batches_array), (int*)PyArray_DATA(batches_array) + Nb);
+	original_points = vector<PointXYZ>((PointXYZ*)PyArray_DATA((PyArrayObject*)points_array), (PointXYZ*)PyArray_DATA((PyArrayObject*)points_array) + N);
+	original_batches = vector<int>((int*)PyArray_DATA((PyArrayObject*)batches_array), (int*)PyArray_DATA((PyArrayObject*)batches_array) + Nb);
 
 	// Subsample
 	vector<PointXYZ> subsampled_points;
@@ -813,13 +813,13 @@ static PyObject* batch_grid_partitionning(PyObject* self, PyObject* args, PyObje
 
 	// Fill output array with values
 	size_t size_in_bytes = subsampled_points.size() * 3 * sizeof(float);
-	memcpy(PyArray_DATA(res_points_obj), subsampled_points.data(), size_in_bytes);
+	memcpy(PyArray_DATA((PyArrayObject*)res_points_obj), subsampled_points.data(), size_in_bytes);
 	size_in_bytes = Nb * sizeof(int);
-	memcpy(PyArray_DATA(res_batches_obj), subsampled_batches.data(), size_in_bytes);
+	memcpy(PyArray_DATA((PyArrayObject*)res_batches_obj), subsampled_batches.data(), size_in_bytes);
 	size_in_bytes = N * sizeof(int);
-	memcpy(PyArray_DATA(res_ups_obj), upsampling_inds.data(), size_in_bytes);
+	memcpy(PyArray_DATA((PyArrayObject*)res_ups_obj), upsampling_inds.data(), size_in_bytes);
 	size_in_bytes = pooling_inds.size() * sizeof(int);
-	memcpy(PyArray_DATA(res_pools_obj), pooling_inds.data(), size_in_bytes);
+	memcpy(PyArray_DATA((PyArrayObject*)res_pools_obj), pooling_inds.data(), size_in_bytes);
 
 
 	// Merge results

--- a/Standalone/README.md
+++ b/Standalone/README.md
@@ -14,6 +14,18 @@ pip install easydict h5py matplotlib numpy scikit-learn timm pykeops
 pip install 'pyvista[all,trame]' jupyterlab
 ```
 
+After running these commands, you will have to compile the C++ extension modules by running these commands:
+
+```bash
+cd KPConvX/cpp_wrappers/cpp_neighbors
+python setup.py build_ext --inplace
+cd ../cpp_subsampling
+python setup.py build_ext --inplace
+```
+
+Note that there might still be issues during the process. For example, the calls to ```python setup.py``` above might give an error about there not being a module named ```distutils.msvccompiler```. In this case, check what is the last file in the traceback, open it, and comment out the import which causes the error (which should be ```from distutils.msvccompiler import get_build_version as get_build_msvc_version```).
+
+Also, when running the training scripts, you might get errors about the linker not finding -lnvrtc. In this case, follow the steps commented in [this GitHub issue](https://github.com/getkeops/keops/issues/318#issuecomment-2361423739) 
 
 ## Prepare data
 


### PR DESCRIPTION
Attempting to run the experiment scripts with the instructions given in the Setup section of ```Standalone/README.md``` results in multiple issues, of which, the most notable is a series of compiler errors of the C++ extensions modules, all of which were of the form ```cannot convert ‘PyObject*’ {aka ‘_object*’} to ‘const PyArrayObject*’ {aka ‘const tagPyArrayObject_fields*’}```

I have fixed this by adding casts to ```PyArrayObject*``` in the places where errors were reported. This, together with some more fixes I have described in the aforementioned ```README.md```, has allowed me to properly run the training script.